### PR TITLE
adds swift 5.6 to the CI matrix; disables SPM plugins on iOS, tvOS, and watchOS

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             matrix:
                 os: [windows-2022, windows-2019]
-                swift: [5.5.3, 5.4.3]
+                swift: [5.6, 5.5.3, 5.4.3]
         steps:
             -   uses: actions/checkout@v2
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-20.04, ubuntu-18.04]
-                swift: [5.5.3, 5.4.3, 5.3.3]
+                swift: [5.6, 5.5.3, 5.4.3, 5.3.3]
         steps:
             -   uses: actions/checkout@v2
             

--- a/NOTICE
+++ b/NOTICE
@@ -1,12 +1,12 @@
-SwiftJSON (swift-json) was created by Kelvin Ma (@taylorswift). 
+the `swift-json` package was created by kelvin ma (@taylorswift). 
 
-You are welcome to contribute to this project at: 
+you are welcome to contribute to this project at: 
 
     https://github.com/kelvin13/swift-json
 
-We do not maintain any other mirrors of this repository, and such 
+we do not maintain any other mirrors of this repository, and such 
 forks of this repository may not carry the most up-to-date code.
 
-Contributors: 
+contributors: 
 
-1.  Kelvin Ma (@taylorswift, 2021–22)
+1.  kelvin ma (@taylorswift, 2021–22)

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,9 @@ executable.targets.append(.executableTarget(name: "JSONBenchmarks",
 
 // cannot build the documentation plugin on these platforms due to 
 // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1299#issuecomment-1089950219
-#if swift(>=5.6) && !os(iOS) && !os(tvOS) && !os(watchOS)
+// cannot build the documentation plugin on windows since apparently 
+// the PackagePlugin module is not available
+#if swift(>=5.6) && !os(iOS) && !os(tvOS) && !os(watchOS) && !os(Windows)
 let future:[Package.Dependency] = 
 [
     .package(url: "https://github.com/swift-biome/swift-documentation-extract", from: "0.1.1")

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,9 @@ executable.targets.append(.executableTarget(name: "JSONBenchmarks",
     ]))
 #endif
 
-#if swift(>=5.6)
+// cannot build the documentation plugin on these platforms due to 
+// https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1299#issuecomment-1089950219
+#if swift(>=5.6) && !os(iOS) && !os(tvOS) && !os(watchOS)
 let future:[Package.Dependency] = 
 [
     .package(url: "https://github.com/swift-biome/swift-documentation-extract", from: "0.1.1")


### PR DESCRIPTION
disabling the [`swift-documentation-extract`](https://github.com/swift-biome/swift-documentation-extract) plugin on these platforms due to https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1299#issuecomment-1089950219 . 

also adds Swift 5.6 to the CI matrix