### PR TITLE
Fix nightly toolchain breakage

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,14 +38,6 @@ jobs:
                         branch:     development
                     -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-08-15-a
                         branch:     development
-                include:
-                    -   os: 
-                            runner: ubuntu-20.04
-                            prefix: ubuntu2004
-                            suffix: ubuntu20.04
-                        swift: 
-                            toolchain:  5.6.2-RELEASE
-                            branch:     swift-5.6.2-release
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,37 +22,62 @@ jobs:
     #                 swift run -c release benchmark .data/ftx.json
     #                 swift run -c release benchmark-aws-ipam .data/aws-ipamd.jsonl
     benchmark-linux:
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.os.runner }}
+        name: ${{ matrix.os.runner }} (${{ matrix.swift.toolchain }})
         strategy:
             matrix:
-                os: [ubuntu-20.04]
-                swift: [DEVELOPMENT-SNAPSHOT-2022-08-09-a]
+                os: 
+                    -   runner: ubuntu-22.04
+                        prefix: ubuntu2204
+                        suffix: ubuntu22.04
+                    -   runner: ubuntu-20.04
+                        prefix: ubuntu2004
+                        suffix: ubuntu20.04
+                swift: 
+                    -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-08-18-a
+                        branch:     development
+                    -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-08-15-a
+                        branch:     development
+                include:
+                    -   os: 
+                            runner: ubuntu-20.04
+                            prefix: ubuntu2004
+                            suffix: ubuntu20.04
+                        swift: 
+                            toolchain:  5.6.2-RELEASE
+                            branch:     swift-5.6.2-release
+
         steps:
             -   uses: actions/checkout@v2
             
             -   name: cache swift toolchains
                 uses: actions/cache@v2
                 with:
-                    path: swift-${{ matrix.swift }}.tar.gz
-                    key: ${{ matrix.os }}:swift:${{ matrix.swift }}
+                    path: swift-${{ matrix.swift.toolchain }}.tar.gz
+                    key: ${{ matrix.os.runner }}:swift:${{ matrix.swift.toolchain }}
                     
             -   name: cache status
                 id:   cache_status
                 uses: andstor/file-existence-action@v1
                 with:
-                    files: swift-${{ matrix.swift }}.tar.gz
+                    files: swift-${{ matrix.swift.toolchain }}.tar.gz
             
             -   name: download swift toolchain 
                 if: steps.cache_status.outputs.files_exists == 'false'
-                run: curl https://download.swift.org/development/$(echo ${{ matrix.os }} | sed 's/[^a-zA-Z0-9]//g')/swift-${{ matrix.swift }}/swift-${{ matrix.swift }}-$(echo ${{ matrix.os }} | sed 's/[^a-zA-Z0-9\.]//g').tar.gz --output swift-${{ matrix.swift }}.tar.gz
+                run:   "curl https://download.swift.org/\
+                        ${{ matrix.swift.branch }}/\
+                        ${{ matrix.os.prefix }}/\
+                        swift-${{ matrix.swift.toolchain }}/\
+                        swift-${{ matrix.swift.toolchain }}-${{ matrix.os.suffix }}.tar.gz \
+                        --output swift-${{ matrix.swift.toolchain }}.tar.gz"
             
             -   name: set up swift
                 run: |
-                    mkdir -p $GITHUB_WORKSPACE/swift-${{ matrix.swift }}
-                    tar -xzf swift-${{ matrix.swift }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift }} --strip 1
-                    echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift }}/usr/bin" >> $GITHUB_PATH
-
-            -   name: run-benchmarks 
+                    mkdir -p $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}
+                    tar -xzf swift-${{ matrix.swift.toolchain }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }} --strip 1
+                    echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}/usr/bin" >> $GITHUB_PATH
+            
+            -   name: run benchmarks 
                 run: |
                     cd Benchmarks
                     mkdir .data && tar -xf data.tar.xz -C .data

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             matrix:
                 os: [windows-2022, windows-2019]
-                swift: [5.6.2, 5.5.3, 5.4.3]
+                swift: [5.6.2, 5.5.3]
         steps:
             -   name: checkout 
                 uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,49 +7,141 @@ on:
         branches: [ master, release/0.2 ]
 
 jobs:
-    build-macos:
+    macos-nightly:
         runs-on: ${{ matrix.os }}
+        name: ${{ matrix.os }} (${{ matrix.swift }})
+        env: 
+            SWIFT_TOOLCHAIN_DIRECTORY: /Library/Developer/Toolchains/swift-${{ matrix.swift }}.xctoolchain
         strategy:
             matrix:
-                os: [macos-12, macos-11]
+                os: 
+                    -   macos-12
+                swift: 
+                    -   DEVELOPMENT-SNAPSHOT-2022-08-18-a
+                    -   DEVELOPMENT-SNAPSHOT-2022-08-15-a
         steps:
             -   uses: actions/checkout@v2
+
+            -   name: cache swift toolchains
+                uses: actions/cache@v2
+                with:
+                    path: swift-${{ matrix.swift }}.pkg
+                    key: ${{ matrix.os }}:swift:${{ matrix.swift }}
+            
+            -   name: cache status
+                id:   cache_status
+                uses: andstor/file-existence-action@v1
+                with:
+                    files: swift-${{ matrix.swift }}.pkg
+            
+            -   name: download swift toolchain 
+                if: steps.cache_status.outputs.files_exists == 'false'
+                run:   "curl https://download.swift.org/development/xcode/\
+                        swift-${{ matrix.swift }}/\
+                        swift-${{ matrix.swift }}-osx.pkg \
+                        --output swift-${{ matrix.swift }}.pkg"
+            
+            -   name: set up swift
+                run: |
+                    sudo installer -pkg swift-${{ matrix.swift }}.pkg -target /
+            
+            -   name: build 
+                run: |
+                    $SWIFT_TOOLCHAIN_DIRECTORY/usr/bin/swift --version
+                    $SWIFT_TOOLCHAIN_DIRECTORY/usr/bin/swift build
+    
+    macos:
+        runs-on: ${{ matrix.os }}
+        name: ${{ matrix.os }} 
+        strategy:
+            matrix:
+                os: 
+                    -   macos-12
+                    -   macos-11
+        steps:
+            -   uses: actions/checkout@v2
+
             -   name: build 
                 run: |
                     swift --version
                     swift build
-    build-linux:
-        runs-on: ${{ matrix.os }}
+    
+    linux:
+        runs-on: ${{ matrix.os.runner }}
+        name: ${{ matrix.os.runner }} (${{ matrix.swift.toolchain }})
         strategy:
             matrix:
-                os: [ubuntu-20.04, ubuntu-18.04]
-                swift: [5.6.2, 5.5.3, 5.4.3, 5.3.3]
+                os: 
+                    -   runner: ubuntu-22.04
+                        prefix: ubuntu2204
+                        suffix: ubuntu22.04
+                    -   runner: ubuntu-20.04
+                        prefix: ubuntu2004
+                        suffix: ubuntu20.04
+                swift: 
+                    -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-08-18-a
+                        branch:     development
+                    -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-08-15-a
+                        branch:     development
+                include:
+                    -   os: 
+                            runner: ubuntu-20.04
+                            prefix: ubuntu2004
+                            suffix: ubuntu20.04
+                        swift: 
+                            toolchain:  5.6.2-RELEASE
+                            branch:     swift-5.6.2-release
+                    -   os: 
+                            runner: ubuntu-20.04
+                            prefix: ubuntu2004
+                            suffix: ubuntu20.04
+                        swift: 
+                            toolchain:  5.5.3-RELEASE
+                            branch:     swift-5.5.3-release
+                    -   os: 
+                            runner: ubuntu-20.04
+                            prefix: ubuntu2004
+                            suffix: ubuntu20.04
+                        swift: 
+                            toolchain:  5.4.3-RELEASE
+                            branch:     swift-5.4.3-release
+                    -   os: 
+                            runner: ubuntu-20.04
+                            prefix: ubuntu2004
+                            suffix: ubuntu20.04
+                        swift: 
+                            toolchain:  5.3.3-RELEASE
+                            branch:     swift-5.3.3-release
         steps:
             -   uses: actions/checkout@v2
             
             -   name: cache swift toolchains
                 uses: actions/cache@v2
                 with:
-                    path: swift-${{ matrix.swift }}.tar.gz
-                    key: ${{ matrix.os }}:swift:${{ matrix.swift }}
+                    path: swift-${{ matrix.swift.toolchain }}.tar.gz
+                    key: ${{ matrix.os.runner }}:swift:${{ matrix.swift.toolchain }}
                     
             -   name: cache status
                 id:   cache_status
                 uses: andstor/file-existence-action@v1
                 with:
-                    files: swift-${{ matrix.swift }}.tar.gz
+                    files: swift-${{ matrix.swift.toolchain }}.tar.gz
             
             -   name: download swift toolchain 
                 if: steps.cache_status.outputs.files_exists == 'false'
-                run: curl https://download.swift.org/swift-${{ matrix.swift }}-release/$(echo ${{ matrix.os }} | sed 's/[^a-zA-Z0-9]//g')/swift-${{ matrix.swift }}-RELEASE/swift-${{ matrix.swift }}-RELEASE-$(echo ${{ matrix.os }} | sed 's/[^a-zA-Z0-9\.]//g').tar.gz --output swift-${{ matrix.swift }}.tar.gz
+                run:   "curl https://download.swift.org/\
+                        ${{ matrix.swift.branch }}/\
+                        ${{ matrix.os.prefix }}/\
+                        swift-${{ matrix.swift.toolchain }}/\
+                        swift-${{ matrix.swift.toolchain }}-${{ matrix.os.suffix }}.tar.gz \
+                        --output swift-${{ matrix.swift.toolchain }}.tar.gz"
             
             -   name: set up swift
                 run: |
-                    mkdir -p $GITHUB_WORKSPACE/swift-${{ matrix.swift }}
-                    tar -xzf swift-${{ matrix.swift }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift }} --strip 1
-                    echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift }}/usr/bin" >> $GITHUB_PATH
-
-            -   name: build 
+                    mkdir -p $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}
+                    tar -xzf swift-${{ matrix.swift.toolchain }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }} --strip 1
+                    echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}/usr/bin" >> $GITHUB_PATH
+            -   name: build
                 run: |
                     swift --version
-                    swift build
+                    swift build 

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 /.build
 /.vscode
+/.devcontainer
 /.swift-version
 
 /Package.catalog
-/Package.resolved
 /Packages
 /*.ss
 /swift-biome

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-grammar",
+        "repositoryURL": "https://github.com/kelvin13/swift-grammar",
+        "state": {
+          "branch": null,
+          "revision": "272964fcecfff8b4181251bc9ff8bf76ecacbf57",
+          "version": "0.1.5"
+        }
+      },
+      {
+        "package": "swift-package-catalog",
+        "repositoryURL": "https://github.com/kelvin13/swift-package-catalog",
+        "state": {
+          "branch": null,
+          "revision": "6e71dba093cf72a8a697309401ef5be52d42ddf3",
+          "version": "0.4.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ import PackageDescription
 #if swift(>=5.7) && (os(Linux) || os(macOS))
 let plugins:[Package.Dependency] = 
 [
-    .package(url: "https://github.com/kelvin13/swift-package-catalog", from: "0.2.1")
+    .package(url: "https://github.com/kelvin13/swift-package-catalog", from: "0.4.0")
 ]
 #else 
 let plugins:[Package.Dependency] = []

--- a/Sources/JSON/JSON.LintingDictionary.swift
+++ b/Sources/JSON/JSON.LintingDictionary.swift
@@ -105,6 +105,7 @@ extension JSON
         @inlinable public mutating 
         func pop<T>(_ key:String, _ body:(JSON) throws -> T) rethrows -> T?
         {
+            // https://forums.swift.org/t/does-move-into-closure-argument-make-any-difference/59731
             guard let value:JSON = self.pop(key)
             else 
             {
@@ -112,11 +113,7 @@ extension JSON
             }
             do 
             {
-                #if swift(>=5.8)
-                return try body(_move value)
-                #else 
-                return try body(      value)
-                #endif 
+                return try body(value)
             }
             catch let error 
             {
@@ -145,11 +142,7 @@ extension JSON
             let value:JSON = try self.remove(key)
             do 
             {
-                #if swift(>=5.8)
-                return try body(_move value)
-                #else 
-                return try body(      value)
-                #endif 
+                return try body(value)
             }
             catch let error 
             {


### PR DESCRIPTION
fixes #48 . 

also: 

* reinstates the `Package.resolved`
* adds nightly toolchains to the CI matrix on macOS and linux